### PR TITLE
Warnings

### DIFF
--- a/lib/bandsintown.rb
+++ b/lib/bandsintown.rb
@@ -3,7 +3,7 @@ $:.unshift(File.dirname(__FILE__)) unless
 
 require 'rubygems'
 require 'cgi'
-require 'active_support'
+require 'active_support/all'
 require 'json'
 require 'rest_client'
 

--- a/lib/bandsintown/artist.rb
+++ b/lib/bandsintown/artist.rb
@@ -126,7 +126,7 @@ module Bandsintown
     end
     
     def self.build_from_json(json_hash)
-      returning Bandsintown::Artist.new({}) do |artist|
+      Bandsintown::Artist.new({}).tap do |artist|
         artist.name = json_hash['name']
         artist.mbid = json_hash['mbid']
         artist.bandsintown_url = json_hash['url']
@@ -153,6 +153,5 @@ module Bandsintown
         "http://www.bandsintown.com/mbid_#{@mbid}"
       end
     end
-    
   end
 end

--- a/lib/bandsintown/event.rb
+++ b/lib/bandsintown/event.rb
@@ -250,7 +250,7 @@ module Bandsintown
     end
     
     def self.build_from_json(json_hash)
-      returning Bandsintown::Event.new do |event|
+      Bandsintown::Event.new.tap do |event|
         event.bandsintown_id   = json_hash["id"]
         event.bandsintown_url  = json_hash["url"]
         event.datetime         = Time.parse(json_hash["datetime"])
@@ -262,7 +262,5 @@ module Bandsintown
         event.artists          = json_hash["artists"].map { |artist| Bandsintown::Artist.new(artist.symbolize_keys) }
       end
     end
-
-    
   end
 end

--- a/lib/bandsintown/venue.rb
+++ b/lib/bandsintown/venue.rb
@@ -4,7 +4,7 @@ module Bandsintown
     
     #Note - address and postalcode are not returned in API responses, but they are accepted when passing venue data to Bandsintown::Event.create.
     attr_accessor :address, :postalcode
-        
+    
     def initialize(bandsintown_id)
       @bandsintown_id = bandsintown_id
     end 
@@ -52,13 +52,13 @@ module Bandsintown
     def self.search(options = {})
       self.request_and_parse(:get, "search", options).map { |venue_hash| Bandsintown::Venue.build_from_json(venue_hash) }
     end
-
+    
     def self.resource_path
       "venues"
     end
      
     def self.build_from_json(args={})
-      returning Bandsintown::Venue.new(args['id']) do |v|
+      Bandsintown::Venue.new(args['id']).tap do |v|
         v.name            = args["name"]
         v.bandsintown_url = args["url"]
         v.bandsintown_id  = args["id"]
@@ -68,6 +68,6 @@ module Bandsintown
         v.latitude        = args["latitude"]
         v.longitude       = args["longitude"]
       end
-    end    
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ begin
 rescue LoadError
   require 'rubygems'
   gem 'rspec'
-  require 'spec'
+  #require 'spec'
 end
 
 $:.unshift(File.dirname(__FILE__) + '/../lib')


### PR DESCRIPTION
I updated the gem to use `tap` instead of `returning`, so it doesn't throw around with deprecation warnings when using Rails 3+. All tests pass after I commented out `require "spec"` to make it work with the latest rspec version.
