### PR TITLE
Bump version for gemspec + bugfix in event.rb

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+== 0.3.2 2014-12-14
+* Bumped version for bugfix in event.rb
+
 == 0.3.1 2010-07-05
 * Fixed bug for API methods with a blank method name in the route (events - create and artists - create), "/artists/" => "/artists"
 

--- a/bandsintown.gemspec
+++ b/bandsintown.gemspec
@@ -1,0 +1,6 @@
+Gem::Specification.new do |s|
+  s.name        = 'bandsintown'
+  s.version     = '0.3.2'
+  s.date        = '2014-12-14'
+  s.files       = ["lib/bandsintown.rb"]
+end

--- a/lib/bandsintown.rb
+++ b/lib/bandsintown.rb
@@ -14,7 +14,7 @@ require 'bandsintown/event'
 require 'bandsintown/venue'
 
 module Bandsintown
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
   class APIError < StandardError; end
   class << self
     # All Bandsintown API requests require an app_id parameter for identification.


### PR DESCRIPTION
Changes in commit 8d18394f67611cf54611b72acad4345572a6d169 were necessary for me to get this gem working - It would be nice to bump the version and tag a release so the updated version can be served through rubygems.org.  Thank you for the gem!
